### PR TITLE
Doc: Fix link to filter-elastic_integration github repo

### DIFF
--- a/docs/lsr/plugins-filters-elastic_integration.md
+++ b/docs/lsr/plugins-filters-elastic_integration.md
@@ -15,7 +15,7 @@ For other versions, see the [Versioned plugin docs](/vpr/filter-elastic_integrat
 
 ## Getting help [_getting_help_137]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-0-1-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-0-1-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1808]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Enterprise Elastic License.

--- a/docs/vpr/v0-0-2-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-0-2-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1807]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Enterprise Elastic License.

--- a/docs/vpr/v0-0-3-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-0-3-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1806]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Enterprise Elastic License.

--- a/docs/vpr/v0-1-0-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-0-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1805]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Enterprise Elastic License.

--- a/docs/vpr/v0-1-10-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-10-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1796]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-11-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-11-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1795]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-12-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-12-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1794]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-13-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-13-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1793]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-14-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-14-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1792]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-15-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-15-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1791]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-16-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-16-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1790]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-17-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-17-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1789]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-2-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-2-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1804]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Enterprise Elastic License.

--- a/docs/vpr/v0-1-3-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-3-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1803]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-4-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-4-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1802]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-5-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-5-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1801]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-6-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-6-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1800]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-7-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-7-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1799]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-8-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-8-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1798]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v0-1-9-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v0-1-9-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1797]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v8-16-0-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v8-16-0-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1788]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v8-16-1-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v8-16-1-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1787]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v8-17-0-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v8-17-0-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1786]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).

--- a/docs/vpr/v8-17-1-plugins-filters-elastic_integration.md
+++ b/docs/vpr/v8-17-1-plugins-filters-elastic_integration.md
@@ -17,7 +17,7 @@ To learn more about Logstash, see the [Logstash Reference](logstash://reference/
 
 ## Getting help [_getting_help_1785]
 
-For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/logstash-plugins/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
+For questions about the plugin, open a topic in the [Discuss](http://discuss.elastic.co) forums. For bugs or feature requests, open an issue in [Github](https://github.com/elastic/logstash-filter-elastic_integration). For the list of Elastic supported plugins, please consult the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_logstash_plugins).
 
 ::::{admonition} Elastic Enterprise License
 Use of this plugin requires an active Elastic Enterprise [subscription](https://www.elastic.co/subscriptions).


### PR DESCRIPTION
Related: https://github.com/elastic/logstash-filter-elastic_integration/issues/286

This PR fixes the link in the generated output for:
- [x] Logstash plugins (LSR)
- [x] Logstash versioned plugins (VPR)

Note that a fix to source file in the plugin repo is also required (as noted in the issue).