### PR TITLE
Doc: Update logstash-filter-grok resources

### DIFF
--- a/docs/lsr/plugins-filters-grok.md
+++ b/docs/lsr/plugins-filters-grok.md
@@ -28,7 +28,7 @@ This tool is perfect for syslog logs, apache and other webserver logs, mysql log
 
 Logstash ships with about 120 patterns by default. You can find them here: [https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns](https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns). You can add your own trivially. (See the `patterns_dir` setting)
 
-If you need help building patterns to match your logs, you will find the [http://grokdebug.herokuapp.com](http://grokdebug.herokuapp.com) and [http://grokconstructor.appspot.com/](http://grokconstructor.appspot.com/) applications quite useful!
+If you need help building patterns to match your logs, you may find the [http://grokconstructor.appspot.com/](http://grokconstructor.appspot.com/) application quite useful!
 
 ### Grok or Dissect? Or both? [_grok_or_dissect_or_both]
 
@@ -40,7 +40,7 @@ You can use both Dissect and Grok for a hybrid use case when a section of the li
 
 
 
-## Grok Basics [_grok_basics]
+## Grok basics [_grok_basics]
 
 Grok works by combining text patterns into something that matches your logs.
 
@@ -94,12 +94,12 @@ After the grok filter, the event will have a few extra fields in it:
 * `duration: 0.043`
 
 
-## Regular Expressions [_regular_expressions]
+## Regular expressions [_regular_expressions]
 
 Grok sits on top of regular expressions, so any regular expressions are valid in grok as well. The regular expression library is Oniguruma, and you can see the full supported regexp syntax [on the Oniguruma site](https://github.com/kkos/oniguruma/blob/master/doc/RE).
 
 
-## Custom Patterns [_custom_patterns]
+## Custom patterns [_custom_patterns]
 
 Sometimes logstash doesn’t have a pattern you need. For this, you have a few options.
 
@@ -513,7 +513,7 @@ Add a unique `ID` to the plugin configuration. If no ID is specified, Logstash w
     }
 ```
 
-::::{note} 
+::::{note}
 Variable substitution in the `id` field only supports environment variables and does not support the use of values from the secret store.
 ::::
 

--- a/docs/vpr/v4-4-3-plugins-filters-grok.md
+++ b/docs/vpr/v4-4-3-plugins-filters-grok.md
@@ -28,9 +28,9 @@ Grok is a great way to parse unstructured log data into something structured and
 
 This tool is perfect for syslog logs, apache and other webserver logs, mysql logs, and in general, any log format that is generally written for humans and not computer consumption.
 
-Logstash ships with about 120 patterns by default. You can find them here: [https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns](https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns). You can add your own trivially. (See the `patterns_dir` setting)
+Logstash ships with about 120 patterns by default. You can find them here: [https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns](https://github.com/logstash-plugins/logstash-patterns-core/tree/master/patterns). You can add your own. (See the `patterns_dir` setting)
 
-If you need help building patterns to match your logs, you will find the [http://grokdebug.herokuapp.com](http://grokdebug.herokuapp.com) and [http://grokconstructor.appspot.com/](http://grokconstructor.appspot.com/) applications quite useful!
+If you need help building patterns to match your logs, you may find the [http://grokconstructor.appspot.com/](http://grokconstructor.appspot.com/) application quite useful!
 
 ### Grok or Dissect? Or both? [_grok_or_dissect_or_both]
 
@@ -42,7 +42,7 @@ You can use both Dissect and Grok for a hybrid use case when a section of the li
 
 
 
-## Grok Basics [_grok_basics]
+## Grok basics [_grok_basics]
 
 Grok works by combining text patterns into something that matches your logs.
 
@@ -96,12 +96,12 @@ After the grok filter, the event will have a few extra fields in it:
 * `duration: 0.043`
 
 
-## Regular Expressions [_regular_expressions]
+## Regular expressions [_regular_expressions]
 
 Grok sits on top of regular expressions, so any regular expressions are valid in grok as well. The regular expression library is Oniguruma, and you can see the full supported regexp syntax [on the Oniguruma site](https://github.com/kkos/oniguruma/blob/master/doc/RE).
 
 
-## Custom Patterns [_custom_patterns]
+## Custom patterns [_custom_patterns]
 
 Sometimes logstash doesn’t have a pattern you need. For this, you have a few options.
 


### PR DESCRIPTION
Related: https://github.com/logstash-plugins/logstash-filter-grok/pull/196
Fixes: https://github.com/elastic/docs-content/issues/1420

The issue was fixed in https://github.com/logstash-plugins/logstash-filter-grok/pull/186, but a version bump and publish is required in order for the change to be picked up. 