### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @elastic/ingest-docs
+*  @elastic/logstash-docs


### PR DESCRIPTION
Limit codeowners to @elastic/logstash-docs (a subteam of @elastic/ingest-docs) because this repo is unique (contributors should not edit Markdown files directly).